### PR TITLE
Remove port param from example

### DIFF
--- a/docs/latest/user-guides/settings/integrations/amazon-s3.md
+++ b/docs/latest/user-guides/settings/integrations/amazon-s3.md
@@ -108,7 +108,6 @@ For Amazon S3, integration test sends the JSON file with data into your bucket. 
     "domain":"localhost",
     "method":"GET",
     "uri":"/etc/passwd",
-    "port":45070,
     "protocol":"none",
     "status_code":499,
     "attack_type":"ptrav",


### PR DESCRIPTION
In the example event, the port parameter was specified, which is currently missing. The client drew attention to this.